### PR TITLE
FIX #88: Add torch as a build-time dependency in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "torch"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION

This PR fixes a ModuleNotFoundError: No module named 'torch' that occurs when trying to install the package in a clean environment (e.g., using pip install -e .).

Problem: The setup.py script imports torch at build time. However, because torch was not specified as a build-system requirement, pip would create an isolated build environment that did not have torch installed, causing the installation to fail.

Solution: By adding torch to the build-system.requires list in pyproject.toml, we ensure that pip (or any PEP 517 compliant build tool) installs PyTorch into the isolated build environment before executing setup.py.

This allows the installation to complete successfully without requiring the user to manually install torch beforehand or use the --no-build-isolation flag